### PR TITLE
Exclude files from dist package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+/tests/ export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore


### PR DESCRIPTION
For the time being, when fetching the dist package from composer, all repository files are included.
Using `export-ignore` git attribute would permit to make the dist package ligther (see https://php.watch/articles/composer-gitattributes#export-ignore).
